### PR TITLE
(request.js) EventEmitter memory leak

### DIFF
--- a/src/robotto.js
+++ b/src/robotto.js
@@ -13,7 +13,11 @@ robotto.getRobotsUrl = function(urlP) {
 robotto.fetch = function(urlP, callback) {
     callback = typeof callback === 'function' ? callback : new Function();
 
-    let robotsUrl = this.getRobotsUrl(urlP);
+    let robotsUrl = {
+        url:this.getRobotsUrl(urlP),
+        maxRedirects:4,
+    };
+
 
     request.get(robotsUrl, (err, res, body) => {
         if (err) {


### PR DESCRIPTION
Hi,

When crawling a link for robots.txt with a redirect loop,  request.js throws the following error:

`(node:23420) Warning: Possible EventEmitter memory leak detected. 11 pipe listeners added. Use emitter.setMaxListeners() to increase limit`

It will be good to have a limit on the maximum Redirects. Google supports upto 4 redirects for robots.txt 

I have update robotsUrl to an object of options with maxRedirects set to 4 (defaults to 20). It will prevent crashing of the process and will also not waste server resource.